### PR TITLE
feat: Add more units across all categories with conversions

### DIFF
--- a/src/data/units.ts
+++ b/src/data/units.ts
@@ -10,6 +10,13 @@ const lengthUnits: Unit[] = [
   { id: 'foot', name: '피트', symbol: 'ft', toBase: 0.3048, category: 'length', aliases: ['ft', '피트', "'"] },
   { id: 'yard', name: '야드', symbol: 'yd', toBase: 0.9144, category: 'length', aliases: ['yd', '야드'] },
   { id: 'mile', name: '마일', symbol: 'mi', toBase: 1609.34, category: 'length', aliases: ['mi', '마일'] },
+  { id: 'micrometer', name: '마이크로미터', symbol: 'µm', toBase: 0.000001, category: 'length', aliases: ['µm', 'micrometer', '마이크론', 'micron'] },
+  { id: 'nanometer', name: '나노미터', symbol: 'nm', toBase: 1e-9, category: 'length', aliases: ['nm', 'nanometer', '나노미터'] },
+  { id: 'angstrom', name: '옹스트롬', symbol: 'Å', toBase: 1e-10, category: 'length', aliases: ['Å', 'angstrom', '옹스트롬'] },
+  { id: 'nautical_mile', name: '해리', symbol: 'nmi', toBase: 1852, category: 'length', aliases: ['nmi', 'nautical mile', '해리'] },
+  { id: 'furlong', name: '펄롱', symbol: 'fur', toBase: 201.168, category: 'length', aliases: ['fur', 'furlong', '펄롱'] },
+  { id: 'chain', name: '체인', symbol: 'ch', toBase: 20.1168, category: 'length', aliases: ['ch', 'chain', '체인'] },
+  { id: 'rod', name: '로드', symbol: 'rd', toBase: 5.0292, category: 'length', aliases: ['rd', 'rod', '로드', 'perch', 'pole'] },
 ]
 
 // 무게 단위 (킬로그램을 기준으로)
@@ -21,6 +28,10 @@ const weightUnits: Unit[] = [
   { id: 'ounce', name: '온스', symbol: 'oz', toBase: 0.0283495, category: 'weight', aliases: ['oz', '온스'] },
   { id: 'ton', name: '톤', symbol: 't', toBase: 1000, category: 'weight', aliases: ['t', '톤', 'ton'] },
   { id: 'stone', name: '스톤', symbol: 'st', toBase: 6.35029, category: 'weight', aliases: ['st', '스톤'] },
+  { id: 'microgram', name: '마이크로그램', symbol: 'µg', toBase: 1e-9, category: 'weight', aliases: ['µg', 'ug', 'mcg', 'microgram', '마이크로그램'] },
+  { id: 'carat', name: '캐럿', symbol: 'ct', toBase: 0.0002, category: 'weight', aliases: ['ct', 'carat', '캐럿'] },
+  { id: 'dalton', name: '달톤', symbol: 'Da', toBase: 1.66053906660e-27, category: 'weight', aliases: ['Da', 'u', 'amu', 'dalton', 'atomic mass unit', '달톤', '원자질량단위'] },
+  { id: 'slug', name: '슬러그', symbol: 'sl', toBase: 14.59390, category: 'weight', aliases: ['sl', 'slug', '슬러그'] },
 ]
 
 // 부피 단위 (리터를 기준으로)
@@ -34,6 +45,11 @@ const volumeUnits: Unit[] = [
   { id: 'fluid_ounce', name: '액량온스', symbol: 'fl oz', toBase: 0.0295735, category: 'volume', aliases: ['fl oz', '액량온스'] },
   { id: 'tablespoon', name: '테이블스푼', symbol: 'tbsp', toBase: 0.0147868, category: 'volume', aliases: ['tbsp', '테이블스푼'] },
   { id: 'teaspoon', name: '티스푼', symbol: 'tsp', toBase: 0.00492892, category: 'volume', aliases: ['tsp', '티스푼'] },
+  { id: 'cubic_meter', name: '세제곱미터', symbol: 'm³', toBase: 1000, category: 'volume', aliases: ['m³', 'm3', 'cubic meter', '세제곱미터', '큐빅미터'] },
+  { id: 'cubic_centimeter', name: '세제곱센티미터', symbol: 'cm³', toBase: 0.001, category: 'volume', aliases: ['cm³', 'cm3', 'cc', 'cubic centimeter', '세제곱센티미터'] },
+  { id: 'cubic_inch', name: '세제곱인치', symbol: 'in³', toBase: 0.016387064, category: 'volume', aliases: ['in³', 'in3', 'cubic inch', '세제곱인치'] },
+  { id: 'cubic_foot', name: '세제곱피트', symbol: 'ft³', toBase: 28.316846592, category: 'volume', aliases: ['ft³', 'ft3', 'cubic foot', '세제곱피트'] },
+  { id: 'oil_barrel', name: '배럴 (석유)', symbol: 'bbl', toBase: 158.987294928, category: 'volume', aliases: ['bbl', 'oil barrel', '석유배럴'] },
 ]
 
 // 온도 단위 (특별 처리 - 기준값은 의미없음)
@@ -42,6 +58,10 @@ const temperatureUnits: Unit[] = [
   { id: 'fahrenheit', name: '화씨', symbol: '°F', toBase: 1, category: 'temperature', aliases: ['°F', '화씨', 'F'] },
   { id: 'kelvin', name: '켈빈', symbol: 'K', toBase: 1, category: 'temperature', aliases: ['K', '켈빈'] },
   { id: 'rankine', name: '랭킨', symbol: '°R', toBase: 1, category: 'temperature', aliases: ['°R', '랭킨', 'R'] },
+  { id: 'reaumur', name: '열씨', symbol: '°Ré', toBase: 1, category: 'temperature', aliases: ['°Ré', '°Re', 'Re', 'Ré', '열씨'] },
+  { id: 'romer', name: '뢰머', symbol: '°Rø', toBase: 1, category: 'temperature', aliases: ['°Rø', 'Rø', '뢰머'] },
+  { id: 'newton_scale', name: '뉴턴도', symbol: '°N', toBase: 1, category: 'temperature', aliases: ['°N', 'N', 'newton scale', '뉴턴도'] },
+  { id: 'delisle', name: '드릴', symbol: '°D', toBase: 1, category: 'temperature', aliases: ['°D', 'D', 'delisle', '드릴'] },
 ]
 
 // 시간 단위 (초를 기준으로)
@@ -54,6 +74,12 @@ const timeUnits: Unit[] = [
   { id: 'week', name: '주', symbol: 'wk', toBase: 604800, category: 'time', aliases: ['wk', '주', 'week'] },
   { id: 'month', name: '월', symbol: 'mo', toBase: 2629746, category: 'time', aliases: ['mo', '월', 'month'] },
   { id: 'year', name: '년', symbol: 'yr', toBase: 31556952, category: 'time', aliases: ['yr', '년', 'year'] },
+  { id: 'nanosecond', name: '나노초', symbol: 'ns', toBase: 1e-9, category: 'time', aliases: ['ns', 'nanosecond', '나노초'] },
+  { id: 'microsecond', name: '마이크로초', symbol: 'µs', toBase: 1e-6, category: 'time', aliases: ['µs', 'us', 'microsecond', '마이크로초'] },
+  { id: 'decade', name: '십년', symbol: 'dec', toBase: 315569520, category: 'time', aliases: ['decade', '십년'] },
+  { id: 'century', name: '세기', symbol: 'cen', toBase: 3155695200, category: 'time', aliases: ['century', '세기'] },
+  { id: 'millennium', name: '천년', symbol: 'mil', toBase: 31556952000, category: 'time', aliases: ['millennium', '천년'] },
+  { id: 'fortnight', name: '2주', symbol: 'fn', toBase: 1209600, category: 'time', aliases: ['fn', 'fortnight', '2주'] },
 ]
 
 // 데이터 단위 (바이트를 기준으로)
@@ -74,6 +100,13 @@ const dataUnits: Unit[] = [
   { id: 'gibibyte', name: '기비바이트', symbol: 'GiB', toBase: 1073741824, category: 'data', aliases: ['GiB', '기비바이트'] },
   { id: 'tebibyte', name: '테비바이트', symbol: 'TiB', toBase: 1099511627776, category: 'data', aliases: ['TiB', '테비바이트'] },
   { id: 'pebibyte', name: '페비바이트', symbol: 'PiB', toBase: 1125899906842624, category: 'data', aliases: ['PiB', '페비바이트'] },
+  { id: 'nibble', name: '니블', symbol: 'nibble', toBase: 0.5, category: 'data', aliases: ['nibble', 'nybble', '니블'] },
+  { id: 'exabyte', name: '엑사바이트', symbol: 'EB', toBase: 1e18, category: 'data', aliases: ['EB', 'exabyte', '엑사바이트'] },
+  { id: 'zettabyte', name: '제타바이트', symbol: 'ZB', toBase: 1e21, category: 'data', aliases: ['ZB', 'zettabyte', '제타바이트'] },
+  { id: 'yottabyte', name: '요타바이트', symbol: 'YB', toBase: 1e24, category: 'data', aliases: ['YB', 'yottabyte', '요타바이트'] },
+  { id: 'exbibyte', name: '엑스비바이트', symbol: 'EiB', toBase: 1152921504606846976, category: 'data', aliases: ['EiB', 'exbibyte', '엑스비바이트'] },
+  { id: 'zebibyte', name: '제비바이트', symbol: 'ZiB', toBase: 1180591620717411303424, category: 'data', aliases: ['ZiB', 'zebibyte', '제비바이트'] },
+  { id: 'yobibyte', name: '요비바이트', symbol: 'YiB', toBase: 1208925819614629174706176, category: 'data', aliases: ['YiB', 'yobibyte', '요비바이트'] },
 ]
 
 // 속도 단위 (미터/초를 기준으로)
@@ -84,6 +117,7 @@ const speedUnits: Unit[] = [
   { id: 'foot_per_second', name: '피트/초', symbol: 'ft/s', toBase: 0.3048, category: 'speed', aliases: ['ft/s', '피트/초'] },
   { id: 'knot', name: '노트', symbol: 'kn', toBase: 0.514444, category: 'speed', aliases: ['kn', '노트', 'knot'] },
   { id: 'mach', name: '마하', symbol: 'M', toBase: 343, category: 'speed', aliases: ['M', '마하', 'mach'] },
+  { id: 'speed_of_light', name: '광속', symbol: 'c', toBase: 299792458, category: 'speed', aliases: ['c', 'speed of light', 'light speed', '광속'] },
 ]
 
 // 면적 단위 (제곱미터를 기준으로)
@@ -96,6 +130,9 @@ const areaUnits: Unit[] = [
   { id: 'square_foot', name: '제곱피트', symbol: 'ft²', toBase: 0.092903, category: 'area', aliases: ['ft²', 'ft2', '제곱피트'] },
   { id: 'acre', name: '에이커', symbol: 'ac', toBase: 4046.86, category: 'area', aliases: ['ac', '에이커', 'acre'] },
   { id: 'hectare', name: '헥타르', symbol: 'ha', toBase: 10000, category: 'area', aliases: ['ha', '헥타르'] },
+  { id: 'square_yard', name: '제곱야드', symbol: 'yd²', toBase: 0.83612736, category: 'area', aliases: ['yd²', 'yd2', 'square yard', '제곱야드'] },
+  { id: 'square_mile', name: '제곱마일', symbol: 'mi²', toBase: 2589988.110336, category: 'area', aliases: ['mi²', 'mi2', 'square mile', '제곱마일'] },
+  { id: 'are', name: '아르', symbol: 'a', toBase: 100, category: 'area', aliases: ['a', 'are', '아르'] },
 ]
 
 // 압력 단위 (파스칼을 기준으로)
@@ -107,6 +144,12 @@ const pressureUnits: Unit[] = [
   { id: 'psi', name: 'PSI', symbol: 'psi', toBase: 6894.76, category: 'pressure', aliases: ['psi', 'PSI'] },
   { id: 'torr', name: '토르', symbol: 'Torr', toBase: 133.322, category: 'pressure', aliases: ['Torr', '토르', 'torr'] },
   { id: 'mmhg', name: '수은주밀리미터', symbol: 'mmHg', toBase: 133.322, category: 'pressure', aliases: ['mmHg', '수은주밀리미터'] },
+  { id: 'millibar', name: '밀리바', symbol: 'mbar', toBase: 100, category: 'pressure', aliases: ['mbar', 'mb', 'millibar', '밀리바', 'hPa', 'hectopascal', '헥토파스칼'] },
+  { id: 'pound_force_per_square_foot', name: '제곱피트당 파운드힘', symbol: 'psf', toBase: 47.88025898, category: 'pressure', aliases: ['psf', 'lb/ft²', 'pound per square foot', '제곱피트당 파운드힘'] },
+  { id: 'inch_of_mercury', name: '인치 수은주', symbol: 'inHg', toBase: 3386.389, category: 'pressure', aliases: ['inHg', 'inch of mercury', '인치 수은주'] },
+  { id: 'centimeter_of_water', name: '센티미터 수주', symbol: 'cmH₂O', toBase: 98.0665, category: 'pressure', aliases: ['cmH₂O', 'cmH2O', 'centimeter of water', '센티미터 수주'] },
+  { id: 'inch_of_water', name: '인치 수주', symbol: 'inH₂O', toBase: 249.08891, category: 'pressure', aliases: ['inH₂O', 'inH2O', 'inch of water', '인치 수주'] },
+  { id: 'technical_atmosphere', name: '공학기압', symbol: 'at', toBase: 98066.5, category: 'pressure', aliases: ['at', 'technical atmosphere', '공학기압'] },
 ]
 
 // 에너지 단위 (줄을 기준으로)
@@ -118,6 +161,12 @@ const energyUnits: Unit[] = [
   { id: 'watt_hour', name: '와트시', symbol: 'Wh', toBase: 3600, category: 'energy', aliases: ['Wh', '와트시'] },
   { id: 'kilowatt_hour', name: '킬로와트시', symbol: 'kWh', toBase: 3600000, category: 'energy', aliases: ['kWh', '킬로와트시'] },
   { id: 'btu', name: 'BTU', symbol: 'BTU', toBase: 1055.06, category: 'energy', aliases: ['BTU', 'btu'] },
+  { id: 'electronvolt', name: '전자볼트', symbol: 'eV', toBase: 1.602176634e-19, category: 'energy', aliases: ['eV', 'electronvolt', '전자볼트'] },
+  { id: 'megaelectronvolt', name: '메가전자볼트', symbol: 'MeV', toBase: 1.602176634e-13, category: 'energy', aliases: ['MeV', 'megaelectronvolt', '메가전자볼트'] },
+  { id: 'gigaelectronvolt', name: '기가전자볼트', symbol: 'GeV', toBase: 1.602176634e-10, category: 'energy', aliases: ['GeV', 'gigaelectronvolt', '기가전자볼트'] },
+  { id: 'foot_pound_force', name: '피트파운드힘', symbol: 'ft⋅lbf', toBase: 1.3558179483, category: 'energy', aliases: ['ft⋅lbf', 'ft·lbf', 'ft lbf', 'foot pound', '피트파운드'] },
+  { id: 'therm_us', name: '썸 (미국)', symbol: 'thm (US)', toBase: 105505600, category: 'energy', aliases: ['thm', 'therm', 'therm (US)', '썸'] },
+  { id: 'ton_of_tnt', name: '톤 TNT', symbol: 'tTNT', toBase: 4184000000, category: 'energy', aliases: ['tTNT', 'ton of TNT', '톤 TNT'] },
 ]
 
 // 카테고리 정의

--- a/src/lib/conversion-utils.ts
+++ b/src/lib/conversion-utils.ts
@@ -67,6 +67,18 @@ export function convertTemperature(
       case 'rankine':
         celsius = (value - 491.67) * 5/9
         break
+      case 'reaumur':
+        celsius = value * 5/4
+        break
+      case 'romer':
+        celsius = (value - 7.5) * 40/21
+        break
+      case 'newton_scale':
+        celsius = value * 100/33
+        break
+      case 'delisle':
+        celsius = 100 - (value * 2/3)
+        break
       default:
         throw new Error(`알 수 없는 온도 단위: ${fromUnitId}`)
     }
@@ -86,6 +98,18 @@ export function convertTemperature(
         break
       case 'rankine':
         result = celsius * 9/5 + 491.67
+        break
+      case 'reaumur':
+        result = celsius * 4/5
+        break
+      case 'romer':
+        result = (celsius * 21/40) + 7.5
+        break
+      case 'newton_scale':
+        result = celsius * 33/100
+        break
+      case 'delisle':
+        result = (100 - celsius) * 3/2
         break
       default:
         throw new Error(`알 수 없는 온도 단위: ${toUnitId}`)

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -194,6 +194,13 @@ export const en = {
     foot: 'Foot',
     yard: 'Yard',
     mile: 'Mile',
+    micrometer: 'Micrometer',
+    nanometer: 'Nanometer',
+    angstrom: 'Angstrom',
+    nautical_mile: 'Nautical Mile',
+    furlong: 'Furlong',
+    chain: 'Chain',
+    rod: 'Rod',
     
     // 무게 단위
     milligram: 'Milligram',
@@ -203,6 +210,10 @@ export const en = {
     ounce: 'Ounce',
     ton: 'Ton',
     stone: 'Stone',
+    microgram: 'Microgram',
+    carat: 'Carat',
+    dalton: 'Dalton',
+    slug: 'Slug',
     
     // 부피 단위
     milliliter: 'Milliliter',
@@ -214,12 +225,21 @@ export const en = {
     fluid_ounce: 'Fluid Ounce',
     tablespoon: 'Tablespoon',
     teaspoon: 'Teaspoon',
+    cubic_meter: 'Cubic Meter',
+    cubic_centimeter: 'Cubic Centimeter',
+    cubic_inch: 'Cubic Inch',
+    cubic_foot: 'Cubic Foot',
+    oil_barrel: 'Oil Barrel',
     
     // 온도 단위
     celsius: 'Celsius',
     fahrenheit: 'Fahrenheit',
     kelvin: 'Kelvin',
     rankine: 'Rankine',
+    reaumur: 'Réaumur',
+    romer: 'Rømer',
+    newton_scale: 'Newton Scale',
+    delisle: 'Delisle',
     
     // 시간 단위
     millisecond: 'Millisecond',
@@ -230,6 +250,12 @@ export const en = {
     week: 'Week',
     month: 'Month',
     year: 'Year',
+    nanosecond: 'Nanosecond',
+    microsecond: 'Microsecond',
+    decade: 'Decade',
+    century: 'Century',
+    millennium: 'Millennium',
+    fortnight: 'Fortnight',
     
     // 데이터 단위
     bit: 'Bit',
@@ -244,6 +270,13 @@ export const en = {
     gibibyte: 'Gibibyte',
     tebibyte: 'Tebibyte',
     pebibyte: 'Pebibyte',
+    nibble: 'Nibble',
+    exabyte: 'Exabyte',
+    zettabyte: 'Zettabyte',
+    yottabyte: 'Yottabyte',
+    exbibyte: 'Exbibyte',
+    zebibyte: 'Zebibyte',
+    yobibyte: 'Yobibyte',
     
     // 속도 단위
     meter_per_second: 'Meter per second',
@@ -252,6 +285,7 @@ export const en = {
     foot_per_second: 'Foot per second',
     knot: 'Knot',
     mach: 'Mach',
+    speed_of_light: 'Speed of Light',
     
     // 면적 단위
     square_millimeter: 'Square millimeter',
@@ -262,6 +296,9 @@ export const en = {
     square_foot: 'Square foot',
     acre: 'Acre',
     hectare: 'Hectare',
+    square_yard: 'Square Yard',
+    square_mile: 'Square Mile',
+    are: 'Are',
     
     // 압력 단위
     pascal: 'Pascal',
@@ -271,6 +308,12 @@ export const en = {
     psi: 'PSI',
     torr: 'Torr',
     mmhg: 'Millimeter of mercury',
+    millibar: 'Millibar',
+    pound_force_per_square_foot: 'Pound-force per square foot',
+    inch_of_mercury: 'Inch of Mercury',
+    centimeter_of_water: 'Centimeter of Water',
+    inch_of_water: 'Inch of Water',
+    technical_atmosphere: 'Technical Atmosphere',
     
     // 에너지 단위
     joule: 'Joule',
@@ -279,7 +322,13 @@ export const en = {
     kilocalorie: 'Kilocalorie',
     watt_hour: 'Watt hour',
     kilowatt_hour: 'Kilowatt hour',
-    btu: 'BTU'
+    btu: 'BTU',
+    electronvolt: 'Electronvolt',
+    megaelectronvolt: 'Megaelectronvolt',
+    gigaelectronvolt: 'Gigaelectronvolt',
+    foot_pound_force: 'Foot-pound force',
+    therm_us: 'Therm (US)',
+    ton_of_tnt: 'Ton of TNT'
   },
 
   // 공유 기능

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -189,6 +189,13 @@ export const es = {
     foot: 'Pie',
     yard: 'Yarda',
     mile: 'Milla',
+    micrometer: 'Micrómetro',
+    nanometer: 'Nanómetro',
+    angstrom: 'Angstrom',
+    nautical_mile: 'Milla náutica',
+    furlong: 'Furlong',
+    chain: 'Cadena',
+    rod: 'Rod',
     
     // 무게 단위
     milligram: 'Miligramo',
@@ -198,6 +205,10 @@ export const es = {
     ounce: 'Onza',
     ton: 'Tonelada',
     stone: 'Piedra',
+    microgram: 'Microgramo',
+    carat: 'Quilate',
+    dalton: 'Dalton',
+    slug: 'Slug',
     
     // 부피 단위
     milliliter: 'Mililitro',
@@ -209,12 +220,21 @@ export const es = {
     fluid_ounce: 'Onza líquida',
     tablespoon: 'Cucharada',
     teaspoon: 'Cucharadita',
+    cubic_meter: 'Metro cúbico',
+    cubic_centimeter: 'Centímetro cúbico',
+    cubic_inch: 'Pulgada cúbica',
+    cubic_foot: 'Pie cúbico',
+    oil_barrel: 'Barril de petróleo',
     
     // 온도 단위
     celsius: 'Celsius',
     fahrenheit: 'Fahrenheit',
     kelvin: 'Kelvin',
     rankine: 'Rankine',
+    reaumur: 'Grado Réaumur',
+    romer: 'Grado Rømer',
+    newton_scale: 'Grado Newton',
+    delisle: 'Grado Delisle',
     
     // 시간 단위
     millisecond: 'Milisegundo',
@@ -225,6 +245,12 @@ export const es = {
     week: 'Semana',
     month: 'Mes',
     year: 'Año',
+    nanosecond: 'Nanosegundo',
+    microsecond: 'Microsegundo',
+    decade: 'Década',
+    century: 'Siglo',
+    millennium: 'Milenio',
+    fortnight: 'Dos semanas',
     
     // 데이터 단위
     bit: 'Bit',
@@ -239,6 +265,13 @@ export const es = {
     gibibyte: 'Gibibyte',
     tebibyte: 'Tebibyte',
     pebibyte: 'Pebibyte',
+    nibble: 'Nibble',
+    exabyte: 'Exabyte',
+    zettabyte: 'Zettabyte',
+    yottabyte: 'Yottabyte',
+    exbibyte: 'Exbibyte',
+    zebibyte: 'Zebibyte',
+    yobibyte: 'Yobibyte',
     
     // 속도 단위
     meter_per_second: 'Metro por segundo',
@@ -247,6 +280,7 @@ export const es = {
     foot_per_second: 'Pie por segundo',
     knot: 'Nudo',
     mach: 'Mach',
+    speed_of_light: 'Velocidad de la luz',
     
     // 면적 단위
     square_millimeter: 'Milímetro cuadrado',
@@ -257,6 +291,9 @@ export const es = {
     square_foot: 'Pie cuadrado',
     acre: 'Acre',
     hectare: 'Hectárea',
+    square_yard: 'Yarda cuadrada',
+    square_mile: 'Milla cuadrada',
+    are: 'Área',
     
     // 압력 단위
     pascal: 'Pascal',
@@ -266,6 +303,12 @@ export const es = {
     psi: 'PSI',
     torr: 'Torr',
     mmhg: 'Milímetro de mercurio',
+    millibar: 'Milibar',
+    pound_force_per_square_foot: 'Libra-fuerza por pie cuadrado',
+    inch_of_mercury: 'Pulgada de mercurio',
+    centimeter_of_water: 'Centímetro de agua',
+    inch_of_water: 'Pulgada de agua',
+    technical_atmosphere: 'Atmósfera técnica',
     
     // 에너지 단위
     joule: 'Julio',
@@ -274,7 +317,13 @@ export const es = {
     kilocalorie: 'Kilocaloría',
     watt_hour: 'Vatio hora',
     kilowatt_hour: 'Kilovatio hora',
-    btu: 'BTU'
+    btu: 'BTU',
+    electronvolt: 'Electronvoltio',
+    megaelectronvolt: 'Megaelectronvoltio',
+    gigaelectronvolt: 'Gigaelectronvoltio',
+    foot_pound_force: 'Pie-libra fuerza',
+    therm_us: 'Therm (EE.UU.)',
+    ton_of_tnt: 'Tonelada de TNT'
   },
 
   // 공유 기능

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -206,6 +206,13 @@ export const ja = {
     foot: 'フィート',
     yard: 'ヤード',
     mile: 'マイル',
+    micrometer: 'マイクロメートル',
+    nanometer: 'ナノメートル',
+    angstrom: 'オングストローム',
+    nautical_mile: '海里',
+    furlong: 'ハロン',
+    chain: 'チェーン',
+    rod: 'ロッド',
     
     // 重量単位
     milligram: 'ミリグラム',
@@ -215,6 +222,10 @@ export const ja = {
     ounce: 'オンス',
     ton: 'トン',
     stone: 'ストーン',
+    microgram: 'マイクログラム',
+    carat: 'カラット',
+    dalton: 'ダルトン',
+    slug: 'スラグ',
     
     // 体積単位
     milliliter: 'ミリリットル',
@@ -226,12 +237,21 @@ export const ja = {
     fluid_ounce: '液量オンス',
     tablespoon: '大さじ',
     teaspoon: '小さじ',
+    cubic_meter: '立方メートル',
+    cubic_centimeter: '立方センチメートル',
+    cubic_inch: '立方インチ',
+    cubic_foot: '立方フィート',
+    oil_barrel: '石油バレル',
     
     // 温度単位
     celsius: '摂氏',
     fahrenheit: '華氏',
     kelvin: 'ケルビン',
     rankine: 'ランキン',
+    reaumur: 'レオミュール度',
+    romer: 'レーマー度',
+    newton_scale: 'ニュートン度',
+    delisle: 'ドリル度',
     
     // 時間単位
     millisecond: 'ミリ秒',
@@ -242,6 +262,12 @@ export const ja = {
     week: '週',
     month: '月',
     year: '年',
+    nanosecond: 'ナノ秒',
+    microsecond: 'マイクロ秒',
+    decade: '十年紀',
+    century: '世紀',
+    millennium: '千年紀',
+    fortnight: '2週間',
     
     // データ単位
     bit: 'ビット',
@@ -256,6 +282,13 @@ export const ja = {
     gibibyte: 'ギビバイト',
     tebibyte: 'テビバイト',
     pebibyte: 'ペビバイト',
+    nibble: 'ニブル',
+    exabyte: 'エクサバイト',
+    zettabyte: 'ゼタバイト',
+    yottabyte: 'ヨタバイト',
+    exbibyte: 'エクスビバイト',
+    zebibyte: 'ゼビバイト',
+    yobibyte: 'ヨビバイト',
     
     // 速度単位
     meter_per_second: 'メートル毎秒',
@@ -264,6 +297,7 @@ export const ja = {
     foot_per_second: 'フィート毎秒',
     knot: 'ノット',
     mach: 'マッハ',
+    speed_of_light: '光速',
     
     // 面積単位
     square_millimeter: '平方ミリメートル',
@@ -274,6 +308,9 @@ export const ja = {
     square_foot: '平方フィート',
     acre: 'エーカー',
     hectare: 'ヘクタール',
+    square_yard: '平方ヤード',
+    square_mile: '平方マイル',
+    are: 'アール',
     
     // 圧力単位
     pascal: 'パスカル',
@@ -283,6 +320,12 @@ export const ja = {
     psi: 'PSI',
     torr: 'トール',
     mmhg: '水銀柱ミリメートル',
+    millibar: 'ミリバール',
+    pound_force_per_square_foot: '重量ポンド毎平方フィート',
+    inch_of_mercury: '水銀柱インチ',
+    centimeter_of_water: '水柱センチメートル',
+    inch_of_water: '水柱インチ',
+    technical_atmosphere: '工学気圧',
     
     // エネルギー単位
     joule: 'ジュール',
@@ -291,7 +334,13 @@ export const ja = {
     kilocalorie: 'キロカロリー',
     watt_hour: 'ワット時',
     kilowatt_hour: 'キロワット時',
-    btu: 'BTU'
+    btu: 'BTU',
+    electronvolt: '電子ボルト',
+    megaelectronvolt: 'メガ電子ボルト',
+    gigaelectronvolt: 'ギガ電子ボルト',
+    foot_pound_force: 'フィート重量ポンド',
+    therm_us: 'サーム (米国)',
+    ton_of_tnt: 'TNTトン'
   },
 
   // 共有機能

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -194,6 +194,13 @@ export const ko = {
     foot: '피트',
     yard: '야드',
     mile: '마일',
+    micrometer: '마이크로미터',
+    nanometer: '나노미터',
+    angstrom: '옹스트롬',
+    nautical_mile: '해리',
+    furlong: '펄롱',
+    chain: '체인',
+    rod: '로드',
     
     // 무게 단위
     milligram: '밀리그램',
@@ -203,6 +210,10 @@ export const ko = {
     ounce: '온스',
     ton: '톤',
     stone: '스톤',
+    microgram: '마이크로그램',
+    carat: '캐럿',
+    dalton: '달톤',
+    slug: '슬러그',
     
     // 부피 단위
     milliliter: '밀리리터',
@@ -214,12 +225,21 @@ export const ko = {
     fluid_ounce: '액량온스',
     tablespoon: '테이블스푼',
     teaspoon: '티스푼',
+    cubic_meter: '세제곱미터',
+    cubic_centimeter: '세제곱센티미터',
+    cubic_inch: '세제곱인치',
+    cubic_foot: '세제곱피트',
+    oil_barrel: '배럴 (석유)',
     
     // 온도 단위
     celsius: '섭씨',
     fahrenheit: '화씨',
     kelvin: '켈빈',
     rankine: '랭킨',
+    reaumur: '열씨',
+    romer: '뢰머',
+    newton_scale: '뉴턴도',
+    delisle: '드릴',
     
     // 시간 단위
     millisecond: '밀리초',
@@ -230,6 +250,12 @@ export const ko = {
     week: '주',
     month: '월',
     year: '년',
+    nanosecond: '나노초',
+    microsecond: '마이크로초',
+    decade: '십년',
+    century: '세기',
+    millennium: '천년',
+    fortnight: '2주',
     
     // 데이터 단위
     bit: '비트',
@@ -244,6 +270,13 @@ export const ko = {
     gibibyte: '기비바이트',
     tebibyte: '테비바이트',
     pebibyte: '페비바이트',
+    nibble: '니블',
+    exabyte: '엑사바이트',
+    zettabyte: '제타바이트',
+    yottabyte: '요타바이트',
+    exbibyte: '엑스비바이트',
+    zebibyte: '제비바이트',
+    yobibyte: '요비바이트',
     
     // 속도 단위
     meter_per_second: '미터/초',
@@ -252,6 +285,7 @@ export const ko = {
     foot_per_second: '피트/초',
     knot: '노트',
     mach: '마하',
+    speed_of_light: '광속',
     
     // 면적 단위
     square_millimeter: '제곱밀리미터',
@@ -262,6 +296,9 @@ export const ko = {
     square_foot: '제곱피트',
     acre: '에이커',
     hectare: '헥타르',
+    square_yard: '제곱야드',
+    square_mile: '제곱마일',
+    are: '아르',
     
     // 압력 단위
     pascal: '파스칼',
@@ -271,6 +308,12 @@ export const ko = {
     psi: 'PSI',
     torr: '토르',
     mmhg: '수은주밀리미터',
+    millibar: '밀리바',
+    pound_force_per_square_foot: '제곱피트당 파운드힘',
+    inch_of_mercury: '인치 수은주',
+    centimeter_of_water: '센티미터 수주',
+    inch_of_water: '인치 수주',
+    technical_atmosphere: '공학기압',
     
     // 에너지 단위
     joule: '줄',
@@ -279,7 +322,13 @@ export const ko = {
     kilocalorie: '킬로칼로리',
     watt_hour: '와트시',
     kilowatt_hour: '킬로와트시',
-    btu: 'BTU'
+    btu: 'BTU',
+    electronvolt: '전자볼트',
+    megaelectronvolt: '메가전자볼트',
+    gigaelectronvolt: '기가전자볼트',
+    foot_pound_force: '피트파운드힘',
+    therm_us: '썸 (미국)',
+    ton_of_tnt: '톤 TNT'
   },
 
   // 공유 기능


### PR DESCRIPTION
Adds a significant number of new units to all existing conversion categories:
- Length: Micrometer, Nanometer, Angstrom, Nautical Mile, Furlong, Chain, Rod
- Weight: Microgram, Carat, Dalton, Slug
- Volume: Cubic Meter, Cubic Centimeter, Cubic Inch, Cubic Foot, Oil Barrel
- Temperature: Réaumur, Rømer, Newton Scale, Delisle
- Time: Nanosecond, Microsecond, Decade, Century, Millennium, Fortnight
- Data: Nibble, Exabyte/Zettabyte/Yottabyte (decimal), Exbibyte/Zebibyte/Yobibyte (binary)
- Speed: Speed of Light
- Area: Square Yard, Square Mile, Are
- Pressure: Millibar (hPa), Pound-force/sq ft, inHg, cmH2O, inH2O, Technical Atmosphere
- Energy: Electronvolt (MeV, GeV), Foot-pound force, Therm (US), Ton of TNT

This commit includes:
- Updates to `src/data/units.ts` with the new unit definitions.
- Implementation of conversion logic for the new temperature scales (Réaumur, Rømer, Newton, Delisle) in `src/lib/conversion-utils.ts`.
- Addition of unit name translations for all new units in Korean, English, Japanese, and Spanish locale files (`src/locales/*.ts`).